### PR TITLE
refactor(NavBar): use children to avoid prop drilling

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -4,6 +4,9 @@ import tempWatchedData from "../../data/tempWatchedData";
 import { ResultsMovieDataProps } from "../../types";
 import { WatchedMovieDataProps } from "../../types";
 import NavBar from "../NavBar/NavBar";
+import Logo from "../NavBar/Logo";
+import Search from "../NavBar/Search";
+import NumResults from "../NavBar/NumResults";
 import Main from "../Main/Main";
 
 export default function App() {
@@ -13,7 +16,11 @@ export default function App() {
 
   return (
     <div className="h-svh bg-slate-900 p-6 text-slate-100">
-      <NavBar watched={watched} />
+      <NavBar>
+        <Logo />
+        <Search />
+        <NumResults movies={movies} />
+      </NavBar>
       <Main movies={movies} watched={watched} />
     </div>
   );

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,15 +1,8 @@
-import Logo from "./Logo";
-import Search from "./Search";
-import NumResults from "./NumResults";
-import { WatchedMovieDataProps } from "../../types";
-
 //* NavBar Components
-function NavBar({ watched }: { watched: WatchedMovieDataProps[] }) {
+function NavBar({ children }: React.PropsWithChildren<{}>) {
   return (
     <nav className="grid grid-cols-3 items-center rounded-lg bg-indigo-800 p-4">
-      <Logo />
-      <Search />
-      <NumResults watched={watched} />
+      {children}
     </nav>
   );
 }

--- a/src/components/NavBar/NumResults.tsx
+++ b/src/components/NavBar/NumResults.tsx
@@ -1,9 +1,9 @@
-import { WatchedMovieDataProps } from "../../types";
+import { ResultsMovieDataProps } from "../../types";
 
-function NumResults({ watched }: { watched: WatchedMovieDataProps[] }) {
+function NumResults({ movies }: { movies: ResultsMovieDataProps[] }) {
   return (
     <p className="text- justify-self-end text-lg">
-      Found {watched.length} results
+      Found {movies.length} results
     </p>
   );
 }

--- a/src/components/WatchedBox/WatchedList.tsx
+++ b/src/components/WatchedBox/WatchedList.tsx
@@ -4,7 +4,9 @@ import { WatchedMovieDataProps } from "../../types";
 function WatchedList({ watched }: { watched: WatchedMovieDataProps[] }) {
   return (
     <ul className="list">
-      {watched?.map((movie) => <WatchedMovie movie={movie} />)}
+      {watched?.map((movie) => (
+        <WatchedMovie movie={movie} key={movie.imdbID} />
+      ))}
     </ul>
   );
 }

--- a/src/components/WatchedBox/WatchedMovie.tsx
+++ b/src/components/WatchedBox/WatchedMovie.tsx
@@ -2,7 +2,7 @@ import { WatchedMovieDataProps } from "../../types";
 
 function WatchedMovie({ movie }: { movie: WatchedMovieDataProps }) {
   return (
-    <li className="grid grid-cols-3 gap-2 px-8 py-4" key={movie.imdbID}>
+    <li className="grid grid-cols-3 gap-2 px-8 py-4" >
       <img className="col-span-1 max-h-24" src={movie.poster} />
       <div className="col-span-2 self-center">
         <h3 className="text-xl font-bold">{movie.title}</h3>


### PR DESCRIPTION
### TL;DR

This Pull Request modifies the structure of the NavBar by distributing child components like Logo, Search, and NumResults directly in `App`.

### What changed?

- refactors the `App.tsx` and 'NavBar.tsx' by distributing child components like Logo, Search, and NumResults directly in `App`. 
- changes the NavBar to use children props instead of explicitly setting each component, reducing the props needed in `NavBar`. 
- `NumResults.tsx` is updated to show results based on movies length, and components in 'WatchedBox' are updated for better key handling.

### How to test?

Check if the application's functionality is not broken by testing the display and transition of the components. Code review of the changes in the structure of the components would also be helpful.

### Why make this change?

The aim is to simplify the app structure and make the NavBar more reusable.