### PR TITLE
refactor(Main): use children to avoid prop drilling

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -8,6 +8,9 @@ import Logo from "../NavBar/Logo";
 import Search from "../NavBar/Search";
 import NumResults from "../NavBar/NumResults";
 import Main from "../Main/Main";
+import ResultsBox from "../ResultsBox/ResultsBox";
+import WatchedBox from "../WatchedBox/WatchedBox";
+import ResultsList from "../ResultsBox/ResultsList";
 
 export default function App() {
   const [movies, setMovies] = useState<ResultsMovieDataProps[]>(tempMovieData);
@@ -21,7 +24,12 @@ export default function App() {
         <Search />
         <NumResults movies={movies} />
       </NavBar>
-      <Main movies={movies} watched={watched} />
+      <Main>
+        <ResultsBox>
+          <ResultsList movies={movies} />
+        </ResultsBox>
+        <WatchedBox watched={watched} />
+      </Main>
     </div>
   );
 }

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,22 +1,5 @@
-import WatchedBox from "../WatchedBox/WatchedBox";
-import ResultsBox from "../ResultsBox/ResultsBox";
-import { ResultsMovieDataProps } from "../../types";
-import { WatchedMovieDataProps } from "../../types";
-
-//* Main Components
-function Main({
-  movies,
-  watched,
-}: {
-  movies: ResultsMovieDataProps[];
-  watched: WatchedMovieDataProps[];
-}) {
-  return (
-    <main className="mt-2 grid grid-cols-2 gap-2">
-      <ResultsBox movies={movies} />
-      <WatchedBox watched={watched} />
-    </main>
-  );
+function Main({ children }: React.PropsWithChildren<{}>) {
+  return <main className="mt-2 grid grid-cols-2 gap-2">{children}</main>;
 }
 
 export default Main;

--- a/src/components/ResultsBox/ResultsBox.tsx
+++ b/src/components/ResultsBox/ResultsBox.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
-import ResultsList from "./ResultsList";
-import { ResultsMovieDataProps } from "../../types";
 
-function ResultsBox({ movies }: { movies: ResultsMovieDataProps[] }) {
+function ResultsBox({ children }: React.PropsWithChildren<{}>) {
   const [btnMoviesOpen, setBtnMoviesOpen] = useState(true);
 
   return (
@@ -13,7 +11,7 @@ function ResultsBox({ movies }: { movies: ResultsMovieDataProps[] }) {
       >
         {btnMoviesOpen ? "+" : "-"}
       </button>
-      {btnMoviesOpen && <ResultsList movies={movies} />}
+      {btnMoviesOpen && children}
     </div>
   );
 }


### PR DESCRIPTION
### TL;DR

This Pull Request modifies the structure of the Main and ResultsBox components to improve code reusability and flexibility.

### What changed?

The Main, ResultsBox components have been modified. Previously, these components had hard-coded children. This change allows these components to accept children as props, enhancing their reusability and customizability.

### How to test?

Check if the application's functionality is not broken by testing the display and transition of the components. Code review of the changes in the structure of the components would also be helpful.

### Why make this change?

Improving the flexibility of our components can promote code reusability, readability, and ease of maintenance in the future.

---

